### PR TITLE
add a new viewer

### DIFF
--- a/motioncorr/protocols/protocol_motioncorr.py
+++ b/motioncorr/protocols/protocol_motioncorr.py
@@ -452,7 +452,8 @@ class ProtMotionCorr(ProtAlignMovies):
     def _summary(self):
         summary = []
 
-        if hasattr(self, 'outputMicrographs'):
+        if hasattr(self, 'outputMicrographs') or \
+                hasattr(self, 'outputMicrographsDoseWeighted'):
             summary.append('Aligned %d movies using motioncor2.'
                            % self.inputMovies.get().getSize())
         else:
@@ -650,7 +651,6 @@ def createGlobalAlignmentPlot(meanX, meanY, first, pixSize):
 
     i = first
     # The output and log files list the shifts relative to the first frame.
-
     # ROB unit seems to be pixels since sampling rate is only asked
     # by the program if dose filtering is required
     skipLabels = ceil(len(meanX)/10.0)
@@ -678,4 +678,3 @@ def createGlobalAlignmentPlot(meanX, meanY, first, pixSize):
     plotter.tightLayout()
 
     return plotter
-

--- a/motioncorr/viewers.py
+++ b/motioncorr/viewers.py
@@ -84,30 +84,30 @@ class ProtMotioncorrViewer(ProtocolViewer):
                 return [MicrographsView(self.getProject(),
                                         self.protocol.outputMicrographs)]
             else:
-                self._errors.append('No output micrographs found!')
-                self._showErrors()
+                return [self.errorMessage('No output micrographs found!',
+                                          title="Visualization error")]
 
         elif param == 'doShowMicsDW':
             if getattr(self.protocol, 'outputMicrographsDoseWeighted', None) is not None:
                 return [MicrographsView(self.getProject(),
                                         self.protocol.outputMicrographsDoseWeighted)]
             else:
-                self._errors.append('No output dose-weighted micrographs found!')
-                self._showErrors()
+                return [self.errorMessage('No output dose-weighted micrographs found!',
+                                          title="Visualization error")]
 
         elif param == 'doShowMovies':
             if getattr(self.protocol, 'outputMovies', None) is not None:
                 output = self.protocol.outputMovies
                 return [self.objectView(output, viewParams=viewParamsDef)]
             else:
-                self._errors.append('No output movies found!')
-                self._showErrors()
+                return [self.errorMessage('No output movies found!',
+                                          title="Visualization error")]
 
         elif param == 'doShowFailedMovies':
             self.failedList = self.protocol._readFailedList()
             if not self.failedList:
-                self._errors.append("No failed movies found!")
-                self._showErrors()
+                return [self.errorMessage('No failed movies found!',
+                                          title="Visualization error")]
             else:
                 sqliteFn = self.protocol._getPath('movies_failed.sqlite')
                 self.createFailedMoviesSqlite(sqliteFn)
@@ -129,8 +129,3 @@ class ProtMotioncorrViewer(ProtocolViewer):
     def _findFailedMovies(self, item, row):
         if item.getObjId() not in self.failedList:
             setattr(item, "_appendItem", False)
-
-    def _showErrors(self, param=None):
-        views = []
-        self.errorList(self._errors, views)
-        return views

--- a/motioncorr/viewers.py
+++ b/motioncorr/viewers.py
@@ -41,7 +41,7 @@ class ProtMotioncorrViewer(ProtocolViewer):
 
     _targets = [ProtMotionCorr]
     _environments = [DESKTOP_TKINTER, WEB_DJANGO]
-    _label = 'viewer motioncorr'
+    _label = 'viewer'
 
     def _defineParams(self, form):
         form.addSection(label='Visualization')
@@ -69,22 +69,23 @@ class ProtMotioncorrViewer(ProtocolViewer):
                          'doShowMovies': self._viewParam,
                          'doShowFailedMovies': self._viewParam
                          }
-
-        # If the is some error during the load, just show that instead
-        # of any viewer
-        if self._errors:
-            for k in visualizeDict.keys():
-                visualizeDict[k] = self._showErrors
-
         return visualizeDict
 
     def _viewParam(self, param=None):
+        labelsDef = 'enabled id _filename _samplingRate '
+        labelsDef += '_acquisition._dosePerFrame _acquisition._doseInitial '
+        viewParamsDef = {showj.MODE: showj.MODE_MD,
+                         showj.ORDER: labelsDef,
+                         showj.VISIBLE: labelsDef,
+                         showj.RENDER: None
+                         }
         if param == 'doShowMics':
             if getattr(self.protocol, 'outputMicrographs', None) is not None:
                 return [MicrographsView(self.getProject(),
-                                    self.protocol.outputMicrographs)]
+                                        self.protocol.outputMicrographs)]
             else:
                 self._errors.append('No output micrographs found!')
+                self._showErrors()
 
         elif param == 'doShowMicsDW':
             if getattr(self.protocol, 'outputMicrographsDoseWeighted', None) is not None:
@@ -92,33 +93,22 @@ class ProtMotioncorrViewer(ProtocolViewer):
                                         self.protocol.outputMicrographsDoseWeighted)]
             else:
                 self._errors.append('No output dose-weighted micrographs found!')
+                self._showErrors()
 
         elif param == 'doShowMovies':
             if getattr(self.protocol, 'outputMovies', None) is not None:
-                labelsDef = 'enabled id _filename _samplingRate '
-                labelsDef += '_acquisition._dosePerFrame _acquisition._doseInitial '
-                viewParamsDef = {showj.MODE: showj.MODE_MD,
-                                 showj.ORDER: labelsDef,
-                                 showj.VISIBLE: labelsDef,
-                                 showj.RENDER: None
-                                 }
                 output = self.protocol.outputMovies
                 return [self.objectView(output, viewParams=viewParamsDef)]
             else:
                 self._errors.append('No output movies found!')
+                self._showErrors()
 
         elif param == 'doShowFailedMovies':
             self.failedList = self.protocol._readFailedList()
             if not self.failedList:
                 self._errors.append("No failed movies found!")
+                self._showErrors()
             else:
-                labelsDef = 'enabled id _filename _samplingRate '
-                labelsDef += '_acquisition._dosePerFrame _acquisition._doseInitial '
-                viewParamsDef = {showj.MODE: showj.MODE_MD,
-                                 showj.ORDER: labelsDef,
-                                 showj.VISIBLE: labelsDef,
-                                 showj.RENDER: None
-                                 }
                 sqliteFn = self.protocol._getPath('movies_failed.sqlite')
                 self.createFailedMoviesSqlite(sqliteFn)
                 return [self.objectView(sqliteFn, viewParams=viewParamsDef)]


### PR DESCRIPTION
Instead of opening two output sets by default, provide a viewer to select output to display. Also, a possibility to create a subset of failed movies. @delarosatrevin I'm struggling with self._errors here, it does not raise the message. Any advice?