### PR TITLE
working on 3.1.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+3.1.0:
+    - refactor mc2 protocol for using scratch
+    - use eman2 for psd computation, remove xmipp
+    - do not save unweighted mics by default
+    - clean imports
+    - save only full frame alignment log
 3.0.12 - update mc2 to 1.4.0
 3.0.11 - add missing CUDA_LIB var
 3.0.10 - add mc 1.3.2, rearrange GUI form
@@ -19,14 +25,11 @@
     - add axes in Angstroms for plots
 1.0.3:
     - Fixed indentation bug affecting overlapping parameter
-
 1.0.2:
     - Include protocol.conf to create the source distribution
-
 1.0.1:
 	- Updated viewers imports, added protocols.conf
 	- Removing motioncorr v2.1 and all mc2 versions older than 1.0.x;
 	- Cleaning up protocol GUI form, which, in my opinion, was overloaded with params;
 	- Add mc2 1.2.1 as latest default version
-
 1.0.0 - First version of the plugin

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.0.12'
+__version__ = '3.1.0'
 _references = ['Zheng2017']
 
 

--- a/motioncorr/protocols/protocol_motioncorr.py
+++ b/motioncorr/protocols/protocol_motioncorr.py
@@ -581,17 +581,21 @@ class ProtMotionCorr(ProtAlignMovies):
         total, early, late = 0., 0., 0.
         x, y, xOld, yOld = 0., 0., 0., 0.
         pix = self.getSamplingRate()
-        for frame in range(2, nframes + 1):  # start from the 2nd frame
-            x, y = shiftsX[frame-1], shiftsY[frame-1]
-            d = sqrt((x - xOld) * (x - xOld) + (y - yOld) * (y - yOld))
-            total += d
-            if frame <= cutoff:
-                early += d
-            else:
-                late += d
-            xOld = x
-            yOld = y
-        return list(map(lambda x: pix*x, [total, early, late]))
+        try:
+            for frame in range(2, nframes + 1):  # start from the 2nd frame
+                x, y = shiftsX[frame-1], shiftsY[frame-1]
+                d = sqrt((x - xOld) * (x - xOld) + (y - yOld) * (y - yOld))
+                total += d
+                if frame <= cutoff:
+                    early += d
+                else:
+                    late += d
+                xOld = x
+                yOld = y
+            return list(map(lambda x: pix*x, [total, early, late]))
+        except IndexError:
+            self.error("Expected %d frames, found less. Check movie %s !" % (
+                nframes, movie.getFileName()))
 
 
 def createGlobalAlignmentPlot(meanX, meanY, first, pixSize):

--- a/motioncorr/protocols/protocol_motioncorr.py
+++ b/motioncorr/protocols/protocol_motioncorr.py
@@ -30,22 +30,21 @@
 # *
 # ******************************************************************************
 
-import os
 import time
 from math import ceil, sqrt
 from threading import Thread
 
-import pyworkflow.protocol.params as params
 import pyworkflow.protocol.constants as cons
+import pyworkflow.protocol.params as params
 import pyworkflow.utils as pwutils
-import pwem
-from pyworkflow.protocol import STEPS_PARALLEL
+from pwem.objects import Image, Float
 from pwem.protocols import ProtAlignMovies
 from pyworkflow.gui.plotter import Plotter
+from pyworkflow.protocol import STEPS_PARALLEL
 
 from .. import Plugin
-from ..convert import *
 from ..constants import *
+from ..convert import *
 
 
 class ProtMotionCorr(ProtAlignMovies):
@@ -131,18 +130,16 @@ class ProtMotionCorr(ProtAlignMovies):
                       label="Save aligned movie?")
 
         form.addParam('doComputePSD', params.BooleanParam, default=False,
-                      label="Compute PSD (before/after)?",
-                      help="If Yes, the protocol will compute for each movie "
-                           "the average PSD before and after alignment, "
-                           "for comparison")
+                      label="Compute PSD?",
+                      help="If Yes, the protocol will compute for each "
+                           "aligned micrograph the PSD using EMAN2.")
 
         form.addParam('doComputeMicThumbnail', params.BooleanParam,
                       default=False,
                       label='Compute micrograph thumbnail?',
                       help='When using this option, we will compute a '
-                           'micrograph thumbnail and keep it with the '
-                           'micrograph object for visualization purposes.\n\n'
-                           '*IMPORTANT: this requires EMAN2 plugin and binaries.*')
+                           'micrograph thumbnail with EMAN2 and keep it with the '
+                           'micrograph object for visualization purposes. ')
 
         form.addParam('extraProtocolParams', params.StringParam, default='',
                       expertLevel=cons.LEVEL_ADVANCED,
@@ -189,11 +186,12 @@ class ProtMotionCorr(ProtAlignMovies):
                       label='Tolerance (px)',
                       help='Tolerance for iterative alignment, default *0.5px*.')
 
-        form.addParam('doSaveUnweightedMic', params.BooleanParam, default=True,
-                      condition='doSaveAveMic and doApplyDoseFilter',
+        form.addParam('doSaveUnweightedMic', params.BooleanParam, default=False,
+                      condition='doApplyDoseFilter',
                       label="Save unweighted micrographs?",
-                      help="Yes by default, if you have selected to apply a "
-                           "dose-dependent filter to the frames")
+                      help="Aligned but non-dose weighted images are sometimes "
+                           "useful in CTF estimation, although there is no "
+                           "difference in most cases.")
 
         form.addParam('extraParams2', params.StringParam, default='',
                       expertLevel=cons.LEVEL_ADVANCED,
@@ -258,72 +256,20 @@ class ProtMotionCorr(ProtAlignMovies):
     def _processMovie(self, movie):
         inputMovies = self.getInputMovies()
         movieFolder = self._getOutputMovieFolder(movie)
-        outputMicFn = self._getRelPath(self._getOutputMicName(movie),
-                                       movieFolder)
-        outputMovieFn = self._getRelPath(self._getOutputMovieName(movie),
-                                         movieFolder)
-        movieBaseName = pwutils.removeExt(movie.getFileName())
-        aveMicFn = movieBaseName + '_uncorrected_avg.mrc'
-        logFile = self._getRelPath(self._getMovieLogFile(movie),
-                                   movieFolder)
-
+        outputMicFn = self._getOutputMicName(movie)
         a0, aN = self._getRange(movie, 'align')
         program = self._getProgram()
-
-        logFileBase = (logFile.replace('0-Full.log', '').replace(
-            '0-Patch-Full.log', ''))
-        # default values for motioncor2 are (1, 1)
-        cropDimX = self.cropDimX.get() or 1
-        cropDimY = self.cropDimY.get() or 1
-
+        logFileBase = self._getMovieRoot(movie) + "_"
         numbOfFrames = self._getNumberOfFrames(movie)
 
-        if self.doApplyDoseFilter:
-            preExp, dose = self._getCorrectedDose(inputMovies)
-        else:
-            preExp, dose = 0.0, 0.0
-
-        # reset values = 1 to 0 (motioncor2 does it automatically,
-        # but we need to keep this for consistency)
-        if self.patchX.get() == 1:
-            self.patchX.set(0)
-        if self.patchY.get() == 1:
-            self.patchY.set(0)
-
-        argsDict = {'-OutMrc': '"%s"' % outputMicFn,
-                    '-Patch': '%d %d' % (self.patchX, self.patchY),
-                    '-MaskCent': '%d %d' % (self.cropOffsetX,
-                                            self.cropOffsetY),
-                    '-MaskSize': '%d %d' % (cropDimX, cropDimY),
-                    '-FtBin': self.binFactor.get(),
-                    '-Tol': self.tol.get(),
-                    '-Group': self.group.get(),
-                    '-FmDose': dose,
-                    '-Throw': '%d' % a0,
-                    '-Trunc': '%d' % (abs(aN - numbOfFrames + 1)),
-                    '-PixSize': inputMovies.getSamplingRate(),
-                    '-kV': inputMovies.getAcquisition().getVoltage(),
-                    '-LogFile': logFileBase,
-                    }
-        argsDict['-InitDose'] = preExp
-        argsDict['-OutStack'] = 1 if self.doSaveMovie else 0
-
-        if self.defectFile.get():
-            argsDict['-DefectFile'] = self.defectFile.get()
-        if self.defectMap.get():
-            argsDict['-DefectMap'] = self.defectMap.get()
-
-        patchOverlap = self.getAttributeValue('patchOverlap', None)
-        if patchOverlap:  # 0 or None is False
-            argsDict['-Patch'] += " %d" % patchOverlap
-
-        if self.doMagCor:
-            argsDict['-Mag'] = '%0.3f %0.3f %0.3f' % (self.scaleMaj,
-                                                      self.scaleMin,
-                                                      self.angDist)
+        argsDict = self._getArgs()
+        argsDict.update({'-OutMrc': '"%s"' % outputMicFn,
+                         '-Throw': '%d' % a0,
+                         '-Trunc': '%d' % (abs(aN - numbOfFrames + 1)),
+                         '-LogFile': logFileBase,
+                         })
 
         ext = pwutils.getExt(movie.getFileName()).lower()
-
         if ext in ['.mrc', '.mrcs']:
             args = ' -InMrc "%s" ' % movie.getBaseName()
         elif ext in ['.tif', '.tiff']:
@@ -333,59 +279,36 @@ class ProtMotionCorr(ProtAlignMovies):
 
         args += ' '.join(['%s %s' % (k, v)
                           for k, v in argsDict.items()])
-
-        if inputMovies.getGain():
-            args += ' -Gain "%s" ' % inputMovies.getGain()
-            args += ' -RotGain %d' % self.gainRot.get()
-            args += ' -FlipGain %d' % self.gainFlip.get()
-
-        if inputMovies.getDark():
-            args += ' -Dark "%s"' % inputMovies.getDark()
-
-        args += ' -Gpu %(GPU)s'
-        args += ' -SumRange 0.0 0.0'  # switch off writing out DWS
         args += ' ' + self.extraParams2.get()
 
         try:
             self.runJob(program, args, cwd=movieFolder,
                         env=Plugin.getEnviron())
-            self._fixMovie(movie)
-
-            # Compute PSDs
-            outMicFn = self._getExtraPath(self._getOutputMicName(movie))
-            if not os.path.exists(outMicFn):
-                # if only DW mic is saved
-                outMicFn = self._getExtraPath(self._getOutputMicWtName(movie))
 
             def _extraWork():
-                if self.doComputePSD:
-                    movieFn = movie.getFileName()
-                    # Compute uncorrected avg mic
-                    self.averageMovie(movie, movieFn, aveMicFn,
-                                      binFactor=self.binFactor.get(),
-                                      dark=inputMovies.getDark(),
-                                      gain=inputMovies.getGain())
-
-                    self.computePSDImages(movie, aveMicFn, outMicFn,
-                                          outputFnCorrected=self._getPsdJpeg(movie))
-
+                # we need to move shifts log to extra dir before parsing
+                logFn = pwutils.join(movieFolder, self._getMovieLogFile(movie))
+                pwutils.moveFile(logFn, self._getExtraPath(self._getMovieLogFile(movie)))
                 self._saveAlignmentPlots(movie, inputMovies.getSamplingRate())
+
+                outMicFn = pwutils.join(movieFolder, self._getMicFn(movie))
+
+                if self.doComputePSD:
+                    self._computePSD(outMicFn, outputFn=self._getPsdCorr(movie))
 
                 if self._doComputeMicThumbnail():
                     self.computeThumbnail(outMicFn,
-                                          outputFn=self._getOutputMicThumbnail(
-                                              movie))
-                # This protocols cleans up the temporary movie folder
-                # which is required mainly when using a thread for this extra work
-                self._cleanMovieFolder(movieFolder)
+                                          outputFn=self._getOutputMicThumbnail(movie))
 
             if self._useWorkerThread():
                 thread = Thread(target=_extraWork)
                 thread.start()
             else:
                 _extraWork()
+
+            self._moveOutput(movie)
         except:
-            print("ERROR: Movie %s failed\n" % movie.getName())
+            self.error("ERROR: Motioncor2 has failed for %s\n" % movie.getFileName())
 
     def _insertFinalSteps(self, deps):
         stepsId = []
@@ -396,9 +319,9 @@ class ProtMotionCorr(ProtAlignMovies):
 
     def waitForThreadStep(self):
         # Quick and dirty (maybe desperate) way to wait
-        # if the PSD and thumbnail were computed with a thread
+        # if the PSD and thumbnail were computed in a thread
         # If running in streaming this will not be necessary
-        time.sleep(60)  # wait 1 min to give some time the thread to finish
+        time.sleep(10)  # wait 10 sec for the thread to finish
 
     # --------------------------- INFO functions ------------------------------
     def _summary(self):
@@ -437,26 +360,90 @@ class ProtMotionCorr(ProtAlignMovies):
                 errors.append('Dose per frame for input movies is 0 or not '
                               'set. You cannot apply dose filter.')
 
+        if self.doComputeMicThumbnail or self.doComputePSD:
+            try:
+                from pwem import Domain
+                eman2 = Domain.importFromPlugin('eman2', doRaise=True)
+            except:
+                errors.append("EMAN2 plugin not found!\nComputing thumbnails "
+                              "or PSD requires EMAN2 plugin and binaries installed.")
+
         return errors
 
     # --------------------------- UTILS functions -----------------------------
+    def _getArgs(self):
+        """ Prepare most arguments for mc2 run. """
+        inputMovies = self.getInputMovies()
+        # default values for motioncor2 are (1, 1)
+        cropDimX = self.cropDimX.get() or 1
+        cropDimY = self.cropDimY.get() or 1
+
+        if self.doApplyDoseFilter:
+            preExp, dose = self._getCorrectedDose(inputMovies)
+        else:
+            preExp, dose = 0.0, 0.0
+
+        # reset values = 1 to 0 (motioncor2 does it automatically,
+        # but we need to keep this for consistency)
+        if self.patchX.get() == 1:
+            self.patchX.set(0)
+        if self.patchY.get() == 1:
+            self.patchY.set(0)
+
+        argsDict = {'-Patch': '%d %d' % (self.patchX, self.patchY),
+                    '-MaskCent': '%d %d' % (self.cropOffsetX,
+                                            self.cropOffsetY),
+                    '-MaskSize': '%d %d' % (cropDimX, cropDimY),
+                    '-FtBin': self.binFactor.get(),
+                    '-Tol': self.tol.get(),
+                    '-Group': self.group.get(),
+                    '-FmDose': dose,
+                    '-PixSize': inputMovies.getSamplingRate(),
+                    '-kV': inputMovies.getAcquisition().getVoltage(),
+                    '-InitDose': preExp,
+                    '-OutStack': 1 if self.doSaveMovie else 0,
+                    '-Gpu': '%(GPU)s',
+                    '-SumRange': "0.0 0.0",  # switch off writing out DWS
+                    }
+
+        if self.defectFile.get():
+            argsDict['-DefectFile'] = "%s" % self.defectFile.get()
+        if self.defectMap.get():
+            argsDict['-DefectMap'] = "%s" % self.defectMap.get()
+
+        patchOverlap = self.getAttributeValue('patchOverlap')
+        if patchOverlap:  # 0 or None is False
+            argsDict['-Patch'] += " %d" % patchOverlap
+
+        if self.doMagCor:
+            argsDict['-Mag'] = '%0.3f %0.3f %0.3f' % (self.scaleMaj,
+                                                      self.scaleMin,
+                                                      self.angDist)
+
+        if inputMovies.getGain():
+            argsDict.update({'-Gain': "%s" % inputMovies.getGain(),
+                             '-RotGain': self.gainRot.get(),
+                             '-FlipGain': self.gainFlip.get()})
+
+        if inputMovies.getDark():
+            argsDict['-Dark'] = "%s" % inputMovies.getDark()
+
+        return argsDict
+
     def _getVersion(self):
         return Plugin.getActiveVersion()
 
     def _getProgram(self):
         return Plugin.getProgram()
 
+    def _getCwdPath(self, movie, path):
+        return pwutils.join(self._getOutputMovieFolder(movie), path)
+
     def _getMovieLogFile(self, movie):
         if self.patchX == 0 and self.patchY == 0:
-            return 'micrograph_%06d_0-Full.log' % movie.getObjId()
+            return '%s_0-Full.log' % self._getMovieRoot(movie)
         else:
-            return 'micrograph_%06d_0-Patch-Full.log' % movie.getObjId()
-
-    def _getAbsPath(self, baseName):
-        return os.path.abspath(self._getExtraPath(baseName))
-
-    def _getRelPath(self, baseName, refPath):
-        return os.path.relpath(self._getExtraPath(baseName), refPath)
+            return '%s_0-Patch-Full.log' % self._getMovieRoot(movie)
 
     def _getNameExt(self, movie, postFix, ext, extra=False):
         fn = self._getMovieRoot(movie) + postFix + '.' + ext
@@ -466,16 +453,33 @@ class ProtMotionCorr(ProtAlignMovies):
         return self._getNameExt(movie, '_global_shifts', 'png', extra=True)
 
     def _getPsdCorr(self, movie):
-        return self._getNameExt(movie, '_psd_comparison', 'psd', extra=True)
-
-    def _getPsdJpeg(self, movie):
-        return self._getNameExt(movie, '_psd', 'jpeg', extra=True)
+        return self._getNameExt(movie, '_psd', 'png', extra=True)
 
     def getInputMovies(self):
         return self.inputMovies.get()
 
+    def _computePSD(self, inputFn, outputFn, scaleFactor=6):
+        """ Generate a thumbnail of the PSD with EMAN2"""
+        args = "%s %s " % (inputFn, outputFn)
+        args += "--process=math.realtofft --meanshrink %s " % scaleFactor
+        args += "--fixintscaling=sane"
+
+        from pwem import Domain
+        eman2 = Domain.importFromPlugin('eman2')
+        from pyworkflow.utils.process import runJob
+        runJob(self._log, eman2.Plugin.getProgram('e2proc2d.py'), args,
+               env=eman2.Plugin.getEnviron())
+
+        return outputFn
+
     def _preprocessOutputMicrograph(self, mic, movie):
         self._setPlotInfo(movie, mic)
+
+    def _getMicFn(self, movie):
+        if self.doApplyDoseFilter:
+            return self._getOutputMicWtName(movie)
+        else:
+            return self._getOutputMicName(movie)
 
     def _getMovieShifts(self, movie):
         """ Returns the x and y shifts for the alignment of this movie.
@@ -487,18 +491,16 @@ class ProtMotionCorr(ProtAlignMovies):
         return xShifts, yShifts
 
     def _setPlotInfo(self, movie, mic):
-        mic.plotGlobal = pwem.objects.Image(location=self._getPlotGlobal(movie))
+        mic.plotGlobal = Image(location=self._getPlotGlobal(movie))
         if self.doComputePSD:
-            mic.psdCorr = pwem.objects.Image(location=self._getPsdCorr(movie))
-            mic.psdJpeg = pwem.objects.Image(location=self._getPsdJpeg(movie))
+            mic.psdCorr = Image(location=self._getPsdCorr(movie))
         if self._doComputeMicThumbnail():
-            mic.thumbnail = pwem.objects.Image(
-                location=self._getOutputMicThumbnail(movie))
+            mic.thumbnail = Image(location=self._getOutputMicThumbnail(movie))
         if self.doApplyDoseFilter:
             total, early, late = self.calcFrameMotion(movie)
-            mic._rlnAccumMotionTotal = pwem.objects.Float(total)
-            mic._rlnAccumMotionEarly = pwem.objects.Float(early)
-            mic._rlnAccumMotionLate = pwem.objects.Float(late)
+            mic._rlnAccumMotionTotal = Float(total)
+            mic._rlnAccumMotionEarly = Float(early)
+            mic._rlnAccumMotionLate = Float(late)
 
     def _saveAlignmentPlots(self, movie, pixSize):
         """ Compute alignment shift plots and save to file as png images. """
@@ -508,20 +510,23 @@ class ProtMotionCorr(ProtAlignMovies):
         plotter.savefig(self._getPlotGlobal(movie))
         plotter.close()
 
-    def _fixMovie(self, movie):
+    def _moveOutput(self, movie):
+        """ Move output from tmp to extra folder. """
+        pwutils.moveFile(self._getCwdPath(movie, self._getMicFn(movie)),
+                         self._getExtraPath(self._getMicFn(movie)))
+
+        if self.doSaveUnweightedMic:
+            pwutils.moveFile(self._getCwdPath(movie, self._getOutputMicName(movie)),
+                             self._getExtraPath(self._getOutputMicName(movie)))
+
         if self.doSaveMovie:
-            outputMicFn = self._getExtraPath(self._getOutputMicName(movie))
+            outputMicFn = self._getCwdPath(movie, self._getOutputMicName(movie))
             outputMovieFn = self._getExtraPath(self._getOutputMovieName(movie))
             movieFn = outputMicFn.replace('_aligned_mic.mrc',
                                           '_aligned_mic_Stk.mrc')
             pwutils.moveFile(movieFn, outputMovieFn)
 
-        if not self.doSaveUnweightedMic:
-            fnToDelete = self._getExtraPath(self._getOutputMicName(movie))
-            pwutils.cleanPath(fnToDelete)
-
     def _getRange(self, movie, prefix):
-
         n = self._getNumberOfFrames(movie)
         iniFrame, _, indxFrame = movie.getFramesRange()
         first, last = self._getFrameRange(n, prefix)
@@ -552,20 +557,16 @@ class ProtMotionCorr(ProtAlignMovies):
         # To create the unweighted average micrographs
         # we only consider the 'doSaveUnweightedMic' flag if the
         # weighted ones should be created.
-        return (self.doSaveAveMic and
-                (not createWeighted or self.doSaveUnweightedMic))
+        return not createWeighted or self.doSaveUnweightedMic
 
     def _createOutputWeightedMicrographs(self):
-        return self.doSaveAveMic and self.doApplyDoseFilter
+        return self.doApplyDoseFilter
 
     def _doComputeMicThumbnail(self):
-        return self.doSaveAveMic and self.doComputeMicThumbnail
+        return self.doComputeMicThumbnail
 
     def _useWorkerThread(self):
         return '--use_worker_thread' in self.extraProtocolParams.get()
-
-    def _doMovieFolderCleanUp(self):
-        return False
 
     def getSamplingRate(self):
         return self.getInputMovies().getSamplingRate()

--- a/motioncorr/tests/test_protocols_motioncor2.py
+++ b/motioncorr/tests/test_protocols_motioncor2.py
@@ -29,7 +29,7 @@
 # **************************************************************************
 
 from pwem.protocols import ProtImportMovies
-from pyworkflow.tests import *
+from pyworkflow.tests import BaseTest, DataSet, setupTestProject
 from pyworkflow.utils import magentaStr
 
 from ..protocols import ProtMotionCorr
@@ -74,7 +74,7 @@ class TestMotioncor2AlignMovies(BaseTest):
                                               magnification=61000)
 
     def _checkMicrographs(self, protocol):
-        self.assertIsNotNone(getattr(protocol, 'outputMicrographs', None),
+        self.assertIsNotNone(getattr(protocol, 'outputMicrographsDoseWeighted'),
                              "Output SetOfMicrographs were not created.")
 
     def _checkAlignment(self, movie, goldRange, goldRoi):

--- a/motioncorr/viewers.py
+++ b/motioncorr/viewers.py
@@ -140,7 +140,7 @@ class ProtMotioncorrViewer(EmProtocolViewer):
             setattr(item, "_appendItem", False)
 
     def _plotMotion(self, param=None):
-        if getattr(self.protocol, 'outputMicrographsDoseWeighted', None) is not None:
+        if self.hasDWMics():
             output = self.protocol.outputMicrographsDoseWeighted
             columns = '_rlnAccumMotionTotal _rlnAccumMotionEarly _rlnAccumMotionLate'
             xplotter = EmPlotter.createFromFile(output.getFileName(), '',

--- a/motioncorr/viewers.py
+++ b/motioncorr/viewers.py
@@ -45,14 +45,16 @@ class ProtMotioncorrViewer(EmProtocolViewer):
 
     def _defineParams(self, form):
         form.addSection(label='Visualization')
-        form.addParam('doShowMics', LabelParam,
-                      label="Show aligned micrographs?", default=True,
-                      help="Show the output aligned micrographs.")
-        form.addParam('doShowMicsDW', LabelParam,
-                      label="Show aligned DOSE-WEIGHTED micrographs?",
-                      default=True,
-                      help="Show the output aligned dose-weighted "
-                           "micrographs.")
+        if self.hasMics():
+            form.addParam('doShowMics', LabelParam,
+                          label="Show aligned micrographs?", default=True,
+                          help="Show the output aligned micrographs.")
+        if self.hasDWMics():
+            form.addParam('doShowMicsDW', LabelParam,
+                          label="Show aligned DOSE-WEIGHTED micrographs?",
+                          default=True,
+                          help="Show the output aligned dose-weighted "
+                               "micrographs.")
         form.addParam('doShowMovies', LabelParam,
                       label="Show output movies?", default=True,
                       help="Show the output movies with alignment "
@@ -68,13 +70,23 @@ class ProtMotioncorrViewer(EmProtocolViewer):
 
     def _getVisualizeDict(self):
         self._errors = []
-        visualizeDict = {'doShowMics': self._viewParam,
-                         'doShowMicsDW': self._viewParam,
-                         'doShowMovies': self._viewParam,
+        visualizeDict = {'doShowMovies': self._viewParam,
                          'doShowFailedMovies': self._viewParam,
                          'doShowMotion': self._plotMotion,
                          }
+        if self.hasMics():
+            visualizeDict.update({'doShowMics': self._viewParam})
+
+        if self.hasDWMics():
+            visualizeDict.update({'doShowMicsDW': self._viewParam})
+
         return visualizeDict
+
+    def hasMics(self):
+        return hasattr(self.protocol, 'outputMicrographs')
+
+    def hasDWMics(self):
+        return hasattr(self.protocol, 'outputMicrographsDoseWeighted')
 
     def _viewParam(self, param=None):
         labelsDef = 'enabled id _filename _samplingRate '
@@ -85,20 +97,12 @@ class ProtMotioncorrViewer(EmProtocolViewer):
                          showj.RENDER: None
                          }
         if param == 'doShowMics':
-            if getattr(self.protocol, 'outputMicrographs', None) is not None:
-                return [MicrographsView(self.getProject(),
-                                        self.protocol.outputMicrographs)]
-            else:
-                return [self.errorMessage('No output micrographs found!',
-                                          title="Visualization error")]
+            return [MicrographsView(self.getProject(),
+                                    self.protocol.outputMicrographs)]
 
         elif param == 'doShowMicsDW':
-            if getattr(self.protocol, 'outputMicrographsDoseWeighted', None) is not None:
-                return [MicrographsView(self.getProject(),
-                                        self.protocol.outputMicrographsDoseWeighted)]
-            else:
-                return [self.errorMessage('No output dose-weighted micrographs found!',
-                                          title="Visualization error")]
+            return [MicrographsView(self.getProject(),
+                                    self.protocol.outputMicrographsDoseWeighted)]
 
         elif param == 'doShowMovies':
             if getattr(self.protocol, 'outputMovies', None) is not None:

--- a/motioncorr/viewers.py
+++ b/motioncorr/viewers.py
@@ -28,10 +28,10 @@
 
 from pyworkflow.utils import cleanPath
 from pyworkflow.viewer import DESKTOP_TKINTER, WEB_DJANGO
-from pwem.viewers import MicrographsView, EmProtocolViewer, EmPlotter
-from pwem.objects import SetOfMovies
 from pyworkflow.protocol.params import LabelParam
+from pwem.viewers import MicrographsView, EmProtocolViewer, EmPlotter
 import pwem.viewers.showj as showj
+from pwem.objects import SetOfMovies
 
 from .protocols import ProtMotionCorr
 


### PR DESCRIPTION
3.1.0:
    - refactor mc2 protocol for using scratch
    - use eman2 for psd computation, remove xmipp
    - do not save unweighted mics by default
    - clean imports
    - save only full frame alignment log
   
JMRT:
    - Compute "extra work" in a thread by default
    - Make thread/no-thread consistent with the results
    - If "extra work" fails, the result is still stored 