### PR TITLE
3.1.0 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.0.12 - update mc2 to 1.4.0
 3.0.11 - add missing CUDA_LIB var
 3.0.10 - add mc 1.3.2, rearrange GUI form
 3.0.9 - fix failing protocol when no dose found

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,9 @@ Motioncor2 is a GPU-accelerated program for correction of electron beam-induced 
 .. |devel| image:: http://scipion-test.cnb.csic.es:9980/badges/motioncorr_devel.svg
 .. |support| image:: http://scipion-test.cnb.csic.es:9980/badges/motioncorr_support.svg
 
-.. important:: If you have imported movies with a gain file in **DM4** format, you need to **flip the gain reference upside-down** in the motioncor2 protocol! (`bug details <https://github.com/I2PC/xmippCore/issues/39>`_)
+**IMPORTANT!**
+
+    If you have imported movies with a gain file in **DM4** format, you need to **flip the gain reference upside-down** in the motioncor2 protocol! (`bug details <https://github.com/I2PC/xmippCore/issues/39>`_)
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,8 @@ b) Developer's version
       scipion installp -p path_to_scipion-em-motioncorr --devel
 
 Motioncor2 binaries will be installed automatically with the plugin, but you can also link an existing installation. 
-Default installation path assumed is ``software/em/motioncor2-1.3.2``, if you want to change it, set *MOTIONCOR2_HOME* in ``scipion.conf`` file to
-the folder where the Motioncor2 is installed. Depending on your CUDA version you might want to change the default binary from ``MotionCor2_1.3.2-Cuda101``
+Default installation path assumed is ``software/em/motioncor2-1.4.0``, if you want to change it, set *MOTIONCOR2_HOME* in ``scipion.conf`` file to
+the folder where the Motioncor2 is installed. Depending on your CUDA version you might want to change the default binary from ``MotionCor2_1.4.0_Cuda101``
 to a different one by explicitly setting *MOTIONCOR2* variable. If you need to use CUDA different from the one used during Scipion installation
 (defined by CUDA_LIB), you can add *MOTIONCOR2_CUDA_LIB* variable to the config file. Various binaries can be downloaded from the official UCSF website.
 
@@ -74,7 +74,7 @@ To check the installation, simply run the following Scipion test:
 Supported versions
 ------------------
 
-1.2.3, 1.2.6, 1.3.0, 1.3.1, 1.3.2
+1.2.6, 1.3.0, 1.3.1, 1.3.2, 1.4.0
 
 Protocols
 ---------

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Motioncor2 is a GPU-accelerated program for correction of electron beam-induced 
 .. |devel| image:: http://scipion-test.cnb.csic.es:9980/badges/motioncorr_devel.svg
 .. |support| image:: http://scipion-test.cnb.csic.es:9980/badges/motioncorr_support.svg
 
+.. important:: If you have imported movies with a gain file in **DM4** format, you need to **flip the gain reference upside-down** in the motioncor2 protocol! (`bug details <https://github.com/I2PC/xmippCore/issues/39>`_)
 
 Installation
 ------------

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -58,7 +58,7 @@ class Plugin(pwem.Plugin):
         """ Return the environment to run motioncor2. """
         environ = pwutils.Environ(os.environ)
         # Get motioncor2 CUDA library path if defined
-        cudaLib = environ.get(MOTIONCOR2_CUDA_LIB, pwem.Config.CUDA_LIB)
+        cudaLib = cls.getVar(MOTIONCOR2_CUDA_LIB, pwem.Config.CUDA_LIB)
         environ.addLibrary(cudaLib)
 
         return environ

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -32,20 +32,20 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.0.11'
+__version__ = '3.0.12'
 _references = ['Zheng2017']
 
 
 class Plugin(pwem.Plugin):
     _homeVar = MOTIONCOR2_HOME
     _pathVars = [MOTIONCOR2_HOME]
-    _supportedVersions = ['1.2.3', '1.2.6', '1.3.0', '1.3.1', '1.3.2']
+    _supportedVersions = ['1.2.6', '1.3.0', '1.3.1', '1.3.2', '1.4.0']
     _url = "https://github.com/scipion-em/scipion-em-motioncorr"
 
     @classmethod
     def _defineVariables(cls):
-        cls._defineEmVar(MOTIONCOR2_HOME, 'motioncor2-1.3.2')
-        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.3.2-Cuda101')
+        cls._defineEmVar(MOTIONCOR2_HOME, 'motioncor2-1.4.0')
+        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.4.0_Cuda101')
         cls._defineVar(MOTIONCOR2_CUDA_LIB, pwem.Config.CUDA_LIB)
 
     @classmethod
@@ -65,9 +65,6 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def defineBinaries(cls, env):
-        env.addPackage('motioncor2', version='1.2.3',
-                       tar='motioncor2-1.2.3.tgz')
-
         env.addPackage('motioncor2', version='1.2.6',
                        tar='motioncor2-1.2.6.tgz')
 
@@ -78,5 +75,8 @@ class Plugin(pwem.Plugin):
                        tar='motioncor2-1.3.1.tgz')
 
         env.addPackage('motioncor2', version='1.3.2',
-                       tar='motioncor2-1.3.2.tgz',
+                       tar='motioncor2-1.3.2.tgz')
+
+        env.addPackage('motioncor2', version='1.4.0',
+                       tar='motioncor2-1.4.0.tgz',
                        default=True)

--- a/motioncorr/protocols/protocol_motioncorr.py
+++ b/motioncorr/protocols/protocol_motioncorr.py
@@ -141,7 +141,8 @@ class ProtMotionCorr(ProtAlignMovies):
                       label='Compute micrograph thumbnail?',
                       help='When using this option, we will compute a '
                            'micrograph thumbnail and keep it with the '
-                           'micrograph object for visualization purposes. ')
+                           'micrograph object for visualization purposes.\n\n'
+                           '*IMPORTANT: this requires EMAN2 plugin and binaries.*')
 
         form.addParam('extraProtocolParams', params.StringParam, default='',
                       expertLevel=cons.LEVEL_ADVANCED,

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ setup(
         #   3 - Alpha
         #   4 - Beta
         #   5 - Production/Stable
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
 
         # Indicate who your project is intended for
         #   'Intended Audience :: Users',


### PR DESCRIPTION
3.1.0:
    - refactor mc2 protocol for using scratch
    - use eman2 for psd computation, remove xmipp
    - do not save unweighted mics by default
    - clean imports
    - save only full frame alignment log
    - Compute "extra work" in a thread by default
    - Make thread/no-thread consistent with the results
    - If "extra work" fails, the result is still stored