### PR TITLE
3.12

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.12:
+    - add mc2 1.6.4 binary
+    - odd/even options working again
 3.11:
     - drop binaries < 1.5.0
     - create a base protocol and refactor the rest

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.9: remove MOTIONCOR2_PROGRAM, improve validation msg
 3.8:
     - guess cuda binary version
     - set gain to output optics table if input movies had one

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.10.1: hotfix for binary string
 3.10: add mc2 1.6.2 and 1.6.3 binaries, fix log name again
 3.9: remove MOTIONCOR2_PROGRAM, improve validation msg
 3.8:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,4 @@
+3.10: add mc2 1.6.2 and 1.6.3 binaries, fix log name again
 3.9: remove MOTIONCOR2_PROGRAM, improve validation msg
 3.8:
     - guess cuda binary version

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+3.8:
+    - guess cuda binary version
+    - set gain to output optics table if input movies had one
 3.7: update mc2 to 1.5.0
 3.6 - implement odd/even sums for SPA
 3.5:

--- a/README.rst
+++ b/README.rst
@@ -58,8 +58,8 @@ b) Developer's version
       scipion installp -p /path/to/scipion-em-motioncorr --devel
 
 - Motioncor2 binaries will be installed automatically with the plugin, but you can also link an existing installation.
-- Default installation path assumed is ``software/em/motioncor2-1.5.0``, if you want to change it, set *MOTIONCOR2_HOME* in ``scipion.conf`` file to the folder where the Motioncor2 is installed.
-- Depending on your CUDA version this plugin will guess the right default binary from ``MotionCor2_1.5.0_CudaXY_05-31-2022`` (X is for cuda major version, Y for the minor). You can always set a different one by explicitly setting *MOTIONCOR2_BIN* variable.
+- Default installation path assumed is ``software/em/motioncor2-1.6.3``, if you want to change it, set *MOTIONCOR2_HOME* in ``scipion.conf`` file to the folder where the Motioncor2 is installed.
+- Depending on your CUDA version this plugin will guess the right default binary from ``MotionCor2_1.6.3_CudaXY_Feb18_2023`` (X is for cuda major version, Y for the minor). You can always set a different one by explicitly setting *MOTIONCOR2_BIN* variable.
 - If you need to use CUDA different from the one used during Scipion installation (defined by CUDA_LIB), you can add *MOTIONCOR2_CUDA_LIB* variable to the config file. Various binaries can be downloaded from the official UCSF website.
 
 For an automatically updated installation of motioncor2 binaries, do not define neither *MOTIONCOR2_HOME* nor *MOTIONCOR2_BIN*.
@@ -79,7 +79,7 @@ Motioncor2 is free for academic use only. For commercial use, please contact Dav
 Supported versions
 ------------------
 
-1.4.0, 1.4.2, 1.4.4, 1.4.5, 1.4.7, 1.5.0
+1.4.0, 1.4.2, 1.4.4, 1.4.5, 1.4.7, 1.5.0, 1.6.2, 1.6.3
 
 Protocols
 ---------

--- a/README.rst
+++ b/README.rst
@@ -58,15 +58,18 @@ b) Developer's version
       scipion installp -p /path/to/scipion-em-motioncorr --devel
 
 - Motioncor2 binaries will be installed automatically with the plugin, but you can also link an existing installation.
-- Default installation path assumed is ``software/em/motioncor2-1.6.3``, if you want to change it, set *MOTIONCOR2_HOME* in ``scipion.conf`` file to the folder where the Motioncor2 is installed.
-- Depending on your CUDA version this plugin will guess the right default binary from ``MotionCor2_1.6.3_CudaXY_Feb18_2023`` (X is for cuda major version, Y for the minor). You can always set a different one by explicitly setting *MOTIONCOR2_BIN* variable.
+- Default installation path assumed is ``software/em/motioncor2-1.6.4``, if you want to change it, set *MOTIONCOR2_HOME* in ``scipion.conf`` file to the folder where the Motioncor2 is installed.
+- Depending on your CUDA version this plugin will guess the right default binary from ``MotionCor2_1.6.4_CudaXY_Mar312023`` (X is for cuda major version, Y for the minor). You can always set a different one by explicitly setting *MOTIONCOR2_BIN* variable.
 - If you need to use CUDA different from the one used during Scipion installation (defined by CUDA_LIB), you can add *MOTIONCOR2_CUDA_LIB* variable to the config file. Various binaries can be downloaded from the official UCSF website.
 
 For an automatically updated installation of motioncor2 binaries, do not define neither *MOTIONCOR2_HOME* nor *MOTIONCOR2_BIN*.
 
-To check the installation, simply run the following Scipion test:
+To check the installation, simply run the following Scipion tests:
 
-``scipion test motioncorr.tests.test_protocols_motioncor2.TestMotioncor2AlignMovies``
+.. code-block::
+
+    scipion test motioncorr.tests.test_protocols_motioncor2.TestMotioncor2AlignMovies
+    scipion test motioncorr.tests.test_protocols_tomo.TestMotioncor2TiltSeriesAlignMovies
 
 Licensing
 ---------
@@ -79,7 +82,7 @@ Motioncor2 is free for academic use only. For commercial use, please contact Dav
 Supported versions
 ------------------
 
-1.4.0, 1.4.2, 1.4.4, 1.4.5, 1.4.7, 1.5.0, 1.6.2, 1.6.3
+1.5.0, 1.6.2, 1.6.3, 1.6.4
 
 Protocols
 ---------

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -32,24 +32,24 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.11'
+__version__ = '3.12'
 _references = ['Zheng2017']
 
 
 class Plugin(pwem.Plugin):
     _homeVar = MOTIONCOR2_HOME
     _pathVars = [MOTIONCOR2_CUDA_LIB]
-    _supportedVersions = ['1.5.0', '1.6.2', '1.6.3']
+    _supportedVersions = ['1.5.0', '1.6.2', '1.6.3', '1.6.4']
     _url = "https://github.com/scipion-em/scipion-em-motioncorr"
 
     @classmethod
     def _defineVariables(cls):
-        cls._defineEmVar(MOTIONCOR2_HOME, 'motioncor2-1.6.3')
+        cls._defineEmVar(MOTIONCOR2_HOME, 'motioncor2-1.6.4')
         cls._defineVar(MOTIONCOR2_CUDA_LIB, pwem.Config.CUDA_LIB)
 
         # Define the variable default value based on the guessed cuda version
         cudaVersion = cls.guessCudaVersion(MOTIONCOR2_CUDA_LIB)
-        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.6.3_Cuda%s%s_Feb18_2023' % (
+        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.6.4_Cuda%s%s_Mar312023' % (
             cudaVersion.major, cudaVersion.minor))
 
     @classmethod
@@ -103,4 +103,4 @@ class Plugin(pwem.Plugin):
         for v in cls._supportedVersions:
             env.addPackage('motioncor2', version=v,
                            tar='motioncor2-%s.tgz' % v,
-                           default=v == '1.6.3')
+                           default=v == '1.6.4')

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.10'
+__version__ = '3.10.1'
 _references = ['Zheng2017']
 
 
@@ -50,7 +50,7 @@ class Plugin(pwem.Plugin):
 
         # Define the variable default value based on the guessed cuda version
         cudaVersion = cls.guessCudaVersion(MOTIONCOR2_CUDA_LIB)
-        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.6.3_Cuda%s%s114_Feb18_2023' % (
+        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.6.3_Cuda%s%s_Feb18_2023' % (
             cudaVersion.major, cudaVersion.minor))
 
 

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -40,7 +40,7 @@ class Plugin(pwem.Plugin):
     _homeVar = MOTIONCOR2_HOME
     _pathVars = [MOTIONCOR2_CUDA_LIB]
     _supportedVersions = ['1.4.0', '1.4.2', '1.4.4', '1.4.5', '1.4.7', '1.5.0']
-    _url = "https://github.com/scipion-em/scipion-em-motioncorr"
+    _url = "https://emcore.ucsf.edu/ucsf-software"
 
     @classmethod
     def _defineVariables(cls):

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -32,13 +32,13 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.8'
+__version__ = '3.9'
 _references = ['Zheng2017']
 
 
 class Plugin(pwem.Plugin):
     _homeVar = MOTIONCOR2_HOME
-    _pathVars = [MOTIONCOR2_PROGRAM, MOTIONCOR2_CUDA_LIB]
+    _pathVars = [MOTIONCOR2_CUDA_LIB]
     _supportedVersions = ['1.4.0', '1.4.2', '1.4.4', '1.4.5', '1.4.7', '1.5.0']
     _url = "https://github.com/scipion-em/scipion-em-motioncorr"
 
@@ -52,14 +52,28 @@ class Plugin(pwem.Plugin):
         cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.5.0_Cuda%s%s_05-31-2022' % (
             cudaVersion.major, cudaVersion.minor))
 
-        # Final program to use
-        defaultProgram = os.path.join(cls.getHome('bin'),
-                                      os.path.basename(cls.getVar(MOTIONCOR2_BIN)))
-        cls._defineVar(MOTIONCOR2_PROGRAM, defaultProgram)
 
     @classmethod
     def getProgram(cls):
-        return cls.getVar(MOTIONCOR2_PROGRAM)
+        return os.path.join(cls.getHome('bin'),
+                            os.path.basename(cls.getVar(MOTIONCOR2_BIN)))
+
+    @classmethod
+    def validateInstallation(cls):
+        """ Check if the binaries are properly installed. """
+        try:
+            if not os.path.exists(cls.getProgram()):
+                return [f"{cls.getProgram()} does not exist, please verify "
+                        "the following variables or edit the config file:\n\n"
+                        f"{MOTIONCOR2_HOME}: {cls.getVar(MOTIONCOR2_HOME)}\n"
+                        f"{MOTIONCOR2_BIN}: {cls.getVar(MOTIONCOR2_BIN)}"]
+
+            if not os.path.exists(cls.getVar(MOTIONCOR2_CUDA_LIB)):
+                return [f"{cls.getVar(MOTIONCOR2_CUDA_LIB)} does not exist, "
+                        f"please verify {MOTIONCOR2_CUDA_LIB} variable."]
+
+        except Exception as e:
+            return ["validateInstallation fails: %s" % e]
 
     @classmethod
     def versionGE(cls, version):

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -32,7 +32,7 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.7'
+__version__ = '3.8'
 _references = ['Zheng2017']
 
 

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -40,7 +40,7 @@ class Plugin(pwem.Plugin):
     _homeVar = MOTIONCOR2_HOME
     _pathVars = [MOTIONCOR2_CUDA_LIB]
     _supportedVersions = ['1.4.0', '1.4.2', '1.4.4', '1.4.5', '1.4.7', '1.5.0']
-    _url = "https://emcore.ucsf.edu/ucsf-software"
+    _url = "https://github.com/scipion-em/scipion-em-motioncorr"
 
     @classmethod
     def _defineVariables(cls):

--- a/motioncorr/__init__.py
+++ b/motioncorr/__init__.py
@@ -32,24 +32,25 @@ import pyworkflow.utils as pwutils
 from .constants import *
 
 
-__version__ = '3.9'
+__version__ = '3.10'
 _references = ['Zheng2017']
 
 
 class Plugin(pwem.Plugin):
     _homeVar = MOTIONCOR2_HOME
     _pathVars = [MOTIONCOR2_CUDA_LIB]
-    _supportedVersions = ['1.4.0', '1.4.2', '1.4.4', '1.4.5', '1.4.7', '1.5.0']
+    _supportedVersions = ['1.4.0', '1.4.2', '1.4.4', '1.4.5', '1.4.7', '1.5.0',
+                          '1.6.2', '1.6.3']
     _url = "https://github.com/scipion-em/scipion-em-motioncorr"
 
     @classmethod
     def _defineVariables(cls):
-        cls._defineEmVar(MOTIONCOR2_HOME, 'motioncor2-1.5.0')
+        cls._defineEmVar(MOTIONCOR2_HOME, 'motioncor2-1.6.3')
         cls._defineVar(MOTIONCOR2_CUDA_LIB, pwem.Config.CUDA_LIB)
 
         # Define the variable default value based on the guessed cuda version
         cudaVersion = cls.guessCudaVersion(MOTIONCOR2_CUDA_LIB)
-        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.5.0_Cuda%s%s_05-31-2022' % (
+        cls._defineVar(MOTIONCOR2_BIN, 'MotionCor2_1.6.3_Cuda%s%s114_Feb18_2023' % (
             cudaVersion.major, cudaVersion.minor))
 
 
@@ -104,4 +105,4 @@ class Plugin(pwem.Plugin):
         for v in cls._supportedVersions:
             env.addPackage('motioncor2', version=v,
                            tar='motioncor2-%s.tgz' % v,
-                           default=v == '1.5.0')
+                           default=v == '1.6.3')

--- a/motioncorr/protocols/protocol_motioncorr.py
+++ b/motioncorr/protocols/protocol_motioncorr.py
@@ -548,7 +548,13 @@ class ProtMotionCorr(ProtAlignMovies):
                                     '-Patch' if usePatches else '')
 
     def _getLogSuffix(self):
-        return '_aligned_mic' if Plugin.versionGE('1.4.7') else '_0'
+        """ Most annoying part... """
+        if Plugin.versionGE('1.6.2'):
+            return ''
+        elif Plugin.versionGE('1.4.7'):
+            return '_aligned_mic'
+        else:
+            return '_0'
 
     def _getNameExt(self, movie, postFix, ext, extra=False):
         fn = self._getMovieRoot(movie) + postFix + '.' + ext

--- a/motioncorr/protocols/protocol_ts_motioncor.py
+++ b/motioncorr/protocols/protocol_ts_motioncor.py
@@ -348,12 +348,17 @@ class ProtTsMotionCorr(ProtTsCorrectMotion):
     # --------------------------- UTILS functions -----------------------------
     def _getMovieLogFile(self, tiltImageM):
         usePatches = self.patchX != 0 or self.patchY != 0
-        return '%s%s%s-Full.log' % (self._getTiltImageMRoot(tiltImageM),
-                                    self._getLogSuffix(),
-                                    '-Patch' if usePatches else '')
 
-    def _getLogSuffix(self):
-        return '' if Plugin.versionGE('1.4.7') else '_0'
+        if Plugin.versionGE('1.6.2'):
+            return '%s%s-Full.log' % (pwutils.removeBaseExt(tiltImageM.getFileName()),
+                                      '-Patch' if usePatches else '')
+        elif Plugin.versionGE('1.4.7'):
+            suffix = ''
+        else:
+            suffix = '_0'
+
+        return '%s%s%s-Full.log' % (self._getTiltImageMRoot(tiltImageM),
+                                    suffix, '-Patch' if usePatches else '')
 
     def _getRange(self, movie, prefix):
         n = self._getNumberOfFrames(movie)

--- a/motioncorr/protocols/protocol_ts_motioncor.py
+++ b/motioncorr/protocols/protocol_ts_motioncor.py
@@ -6,7 +6,7 @@
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
-# * the Free Software Foundation; either version 2 of the License, or
+# * the Free Software Foundation; either version 3 of the License, or
 # * (at your option) any later version.
 # *
 # * This program is distributed in the hope that it will be useful,
@@ -102,7 +102,7 @@ class ProtTsMotionCorr(ProtTsCorrectMotion):
 
         form.addParam('doSaveUnweightedMic', params.BooleanParam, default=True,
                       condition='doApplyDoseFilter',
-                      label="Save unweighted micrographs?",
+                      label="Save unweighted tilt-series?",
                       help="Aligned but non-dose weighted images are sometimes "
                            "useful in CTF estimation, although there is no "
                            "difference in most cases.")
@@ -299,8 +299,8 @@ class ProtTsMotionCorr(ProtTsCorrectMotion):
             self.oddAvgFrameList.append(oddName)
 
         tiFn, tiFnDW = self._getOutputTiltImagePaths(tiltImageM)
-        if not os.path.exists(tiFn):
-            raise Exception("Expected output file '%s' not produced!" % tiFn)
+        if not os.path.exists(tiFn) and not os.path.exists(tiFnDW):
+            raise Exception("Expected output file(s) '%s' not produced!" % tiFn)
 
         if not pwutils.envVarOn('SCIPION_DEBUG_NOCLEAN'):
             pwutils.cleanPath(workingFolder)

--- a/motioncorr/tests/test_protocols_tomo.py
+++ b/motioncorr/tests/test_protocols_tomo.py
@@ -7,7 +7,7 @@
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
-# * the Free Software Foundation; either version 2 of the License, or
+# * the Free Software Foundation; either version 3 of the License, or
 # * (at your option) any later version.
 # *
 # * This program is distributed in the hope that it will be useful,

--- a/motioncorr/tests/test_protocols_tomo.py
+++ b/motioncorr/tests/test_protocols_tomo.py
@@ -25,9 +25,9 @@
 # *
 # **************************************************************************
 
-from pyworkflow.tests import BaseTest, DataSet, setupTestProject
+from pyworkflow.tests import BaseTest, setupTestProject
 from pyworkflow.utils import magentaStr
-
+from tomo.tests import DataSet  # initialization of tomo data set definition
 from tomo.protocols import ProtImportTsMovies
 from ..protocols import ProtTsMotionCorr
 
@@ -36,8 +36,7 @@ class TestMotioncor2TiltSeriesAlignMovies(BaseTest):
     @classmethod
     def setUpClass(cls):
         setupTestProject(cls)
-        cls.dataset = DataSet(folder='tomo-em', name='tomo-em',
-                              files={'empiar': 'EMPIAR-10164'})
+        cls.dataset = DataSet.getDataSet('tomo-em')
         cls.getFileM = cls.dataset.getFile('empiar')
 
     def _runImportTiltSeriesM(self, filesPattern='{TS}_{TO}_{TA}.mrc'):


### PR DESCRIPTION
3.12:
    - add mc2 1.6.4 binary (closes #82)
    - odd/even options working again
3.11:
    - drop binaries < 1.5.0
    - create a base protocol and refactor the rest
    - EER tomo movie processing support (beta)